### PR TITLE
fix(server): Remove optional params count check 

### DIFF
--- a/server/src/io/iohk/armadillo/server/ServerInterpreter.scala
+++ b/server/src/io/iohk/armadillo/server/ServerInterpreter.scala
@@ -296,7 +296,7 @@ class ServerInterpreter[F[_], Raw] private (
 
   private def combineDecodeAsObject(in: Vector[JsonRpcIO.Single[_]]): Json.JsonObject[Raw] => DecodeResult[Vector[_]] = { json =>
     val jsonAsMap = json.fields.toMap
-    if (jsonAsMap.size >= in.count(_.codec.schema.isOptional) && jsonAsMap.size <= in.size) {
+    if (jsonAsMap.size <= in.size) {
       val ss = in.toList.map { case JsonRpcIO.Single(codec, _, name) =>
         jsonAsMap.get(name) match {
           case Some(r) =>

--- a/server/src/io/iohk/armadillo/server/ServerInterpreter.scala
+++ b/server/src/io/iohk/armadillo/server/ServerInterpreter.scala
@@ -296,7 +296,7 @@ class ServerInterpreter[F[_], Raw] private (
 
   private def combineDecodeAsObject(in: Vector[JsonRpcIO.Single[_]]): Json.JsonObject[Raw] => DecodeResult[Vector[_]] = { json =>
     val jsonAsMap = json.fields.toMap
-    if (jsonAsMap.size <= in.size) {
+    if (jsonAsMap.size >= in.count(i => !i.codec.schema.isOptional) && jsonAsMap.size <= in.size) {
       val ss = in.toList.map { case JsonRpcIO.Single(codec, _, name) =>
         jsonAsMap.get(name) match {
           case Some(r) =>

--- a/server/test/src/io/iohk/armadillo/server/AbstractServerSuite.scala
+++ b/server/test/src/io/iohk/armadillo/server/AbstractServerSuite.scala
@@ -118,6 +118,16 @@ trait AbstractServerSuite[Raw, Body, Interpreter] extends AbstractBaseSuite[Raw,
     expectedResponse = JsonRpcResponse.error_v2[Raw](json"""{"code": -32602, "message": "Invalid params"}""", 1)
   )
 
+  test(echo_with_optional_param, "omitting optional param") { p => IO.pure(Right(p._1.map(_ + p._2).getOrElse(p._2))) }(
+    request = JsonRpcRequest.v2[Raw]("echo", json"""{"second": "Test!"}""", 1),
+    expectedResponse = JsonRpcResponse.v2[Raw](json""""Test!"""", 1)
+  )
+
+  test(echo_with_optional_param, "combining optional and required params") { p => IO.pure(Right(p._1.map(_ + p._2).getOrElse(p._2))) }(
+    request = JsonRpcRequest.v2[Raw]("echo", json"""{"first":  "Test!", "second": "Test!"}""", 1),
+    expectedResponse = JsonRpcResponse.v2[Raw](json""""Test!Test!"""", 1)
+  )
+
   test(empty, "empty response")(_ => IO.delay(Right(println("hello from server"))))(
     request = JsonRpcRequest.v2[Raw]("empty", json"""[]""", 1),
     expectedResponse = JsonRpcResponse.v2[Raw](Json.Null, 1)

--- a/server/test/src/io/iohk/armadillo/server/Endpoints.scala
+++ b/server/test/src/io/iohk/armadillo/server/Endpoints.scala
@@ -101,6 +101,11 @@ trait Endpoints {
       .in(param[Entity]("param1"))
       .out[String]("response")
   }
+
+  val echo_with_optional_param: JsonRpcEndpoint[(Option[String], String), Unit, String] = jsonRpcEndpoint(m"echo")
+    .in(param[Option[String]]("first").and(param[String]("second")))
+    .out[String]("echoed")
+
   val empty: JsonRpcEndpoint[Unit, Unit, Unit] = jsonRpcEndpoint(m"empty")
 
   val error_no_data: JsonRpcEndpoint[Unit, JsonRpcError.NoData, Unit] = jsonRpcEndpoint(m"error_no_data")


### PR DESCRIPTION
Checking actual params count towards expected optionals seems to be broken - handling request with optional param omitted fails.

## Description
<!-- The issue(s) this PR relates to or closes -->
This PR relates to closes #39.

<!-- Describe the goal of this PR... -->
This PR aims to fix the situation about checking the amount of provided params towards expected optional inputs count.

## Comments

## Pre-submit checklist
- Branch
    - [ ] Tests are provided (if possible)
    - [x] No compilation warning is added (if possible)
    - [x] No deprecated methods or objects are added
    - [x] Commits have useful messages
- PR
    - [x] Self-reviewed the diff
    - [x] Create a useful and clear PR description
- Documentation
    - [ ] Update README.md file (if relevant)
    - [ ] Update documentation files in docs folder (if relevant)
